### PR TITLE
fix: remove local path from [tool.uv.sources] that breaks downstream installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dist/
 # Gemini
 GEMINI.md
 .claude
+
+# Local uv overrides (dev-only, not for consumers)
+uv.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,5 +51,4 @@ source_dirs = ["src", "tests"]
 package = true
 
 [tool.uv.sources]
-import-deps = { path = "/home/eduardo/work/import-deps", editable = true }
 rut = { path = ".", editable = true }


### PR DESCRIPTION
## Problem

`[tool.uv.sources]` in `pyproject.toml` contains a hardcoded local path:

```toml
import-deps = { path = "/home/eduardo/work/import-deps", editable = true }
```

This propagates to downstream consumers who install `rut` from git via `uv`, causing:

```
error: Failed to download and build `import-deps @ /home/eduardo/work/import-deps`
```

## Fix

- Remove the local `import-deps` path override from `[tool.uv.sources]`
- Keep the `rut = { path = ".", editable = true }` self-reference (harmless)
- Add `uv.toml` to `.gitignore` so you can use a local `uv.toml` for dev overrides without them leaking to consumers

### Recommended local dev workflow

For local `import-deps` development, create an untracked `uv.toml` in the repo root:

```toml
# uv.toml (gitignored — local dev only)
[sources]
import-deps = { path = "/home/eduardo/work/import-deps", editable = true }
```

`uv.toml` takes precedence over `pyproject.toml` for `[tool.uv]` settings ([docs](https://docs.astral.sh/uv/concepts/configuration-files/)), so this gives you the same local editable workflow without affecting consumers.

Closes #3
